### PR TITLE
Perbaiki error migrasi database pekerjaan_orangtua

### DIFF
--- a/app/Database/Migrations/2025-08-02-165545_UpdateUsersTableWithNewFields.php
+++ b/app/Database/Migrations/2025-08-02-165545_UpdateUsersTableWithNewFields.php
@@ -82,62 +82,80 @@ class UpdateUsersTableWithNewFields extends Migration
 
     public function down()
     {
-        // Drop new columns first
-        $this->forge->dropColumn('users', [
-            'nama_panggilan', 'jenis_kelamin', 'no_telp', 'gol_darah', 
-            'nama_ayah', 'nama_ibu', 'alamat_orangtua', 'no_telp_orangtua', 
-            'pekerjaan_orangtua'
-        ]);
+        // Check if columns exist before dropping them
+        $db = \Config\Database::connect();
+        $columns = $db->getFieldNames('users');
         
-        // Rename alamat back to tempat_tinggal
-        $this->forge->modifyColumn('users', [
-            'alamat' => [
-                'name' => 'tempat_tinggal',
-                'type' => 'TEXT',
-                'null' => false
-            ]
-        ]);
+        // Drop new columns only if they exist
+        $newColumns = ['nama_panggilan', 'jenis_kelamin', 'no_telp', 'gol_darah', 
+                      'nama_ayah', 'nama_ibu', 'alamat_orangtua', 'no_telp_orangtua', 
+                      'pekerjaan_orangtua'];
         
-        // Add back old columns (excluding tempat_tinggal since it now exists)
-        $oldFields = [
-            'nim' => [
-                'type' => 'VARCHAR',
-                'constraint' => 20,
-                'null' => false,
-                'unique' => true,
-                'after' => 'id'
-            ],
-            'email' => [
-                'type' => 'VARCHAR',
-                'constraint' => 100,
-                'null' => false,
-                'unique' => true,
-                'after' => 'nama_lengkap'
-            ],
-            'no_wa' => [
-                'type' => 'VARCHAR',
-                'constraint' => 20,
-                'null' => false,
-                'after' => 'email'
-            ],
-            'no_hp' => [
-                'type' => 'VARCHAR',
-                'constraint' => 20,
-                'null' => false,
-                'after' => 'no_wa'
-            ],
-            'pengalaman_organisasi' => [
-                'type' => 'TEXT',
-                'null' => true,
-                'after' => 'penyakit'
-            ],
-            'alasan_mapala' => [
-                'type' => 'TEXT',
-                'null' => false,
-                'after' => 'pengalaman_organisasi'
-            ]
-        ];
+        $columnsToDrop = array_intersect($newColumns, $columns);
+        if (!empty($columnsToDrop)) {
+            $this->forge->dropColumn('users', $columnsToDrop);
+        }
         
-        $this->forge->addColumn('users', $oldFields);
+        // Rename alamat back to tempat_tinggal only if alamat exists
+        if (in_array('alamat', $columns)) {
+            $this->forge->modifyColumn('users', [
+                'alamat' => [
+                    'name' => 'tempat_tinggal',
+                    'type' => 'TEXT',
+                    'null' => false
+                ]
+            ]);
+        }
+        
+        // Add back old columns only if they don't exist
+        $oldColumns = ['nim', 'email', 'no_wa', 'no_hp', 'pengalaman_organisasi', 'alasan_mapala'];
+        $columnsToAdd = array_diff($oldColumns, $columns);
+        
+        if (!empty($columnsToAdd)) {
+            $oldFields = [
+                'nim' => [
+                    'type' => 'VARCHAR',
+                    'constraint' => 20,
+                    'null' => false,
+                    'unique' => true,
+                    'after' => 'id'
+                ],
+                'email' => [
+                    'type' => 'VARCHAR',
+                    'constraint' => 100,
+                    'null' => false,
+                    'unique' => true,
+                    'after' => 'nama_lengkap'
+                ],
+                'no_wa' => [
+                    'type' => 'VARCHAR',
+                    'constraint' => 20,
+                    'null' => false,
+                    'after' => 'email'
+                ],
+                'no_hp' => [
+                    'type' => 'VARCHAR',
+                    'constraint' => 20,
+                    'null' => false,
+                    'after' => 'no_wa'
+                ],
+                'pengalaman_organisasi' => [
+                    'type' => 'TEXT',
+                    'null' => true,
+                    'after' => 'penyakit'
+                ],
+                'alasan_mapala' => [
+                    'type' => 'TEXT',
+                    'null' => false,
+                    'after' => 'pengalaman_organisasi'
+                ]
+            ];
+            
+            // Only add fields that need to be added
+            $fieldsToAdd = array_intersect_key($oldFields, array_flip($columnsToAdd));
+            if (!empty($fieldsToAdd)) {
+                $this->forge->addColumn('users', $fieldsToAdd);
+            }
+        }
     }
 }


### PR DESCRIPTION
Make migration rollback robust by adding column existence checks before dropping, renaming, or adding columns.

The original `down()` method in `2025-08-02-165545_UpdateUsersTableWithNewFields.php` failed during rollback if columns it expected to drop (like `pekerjaan_orangtua`) did not exist, or if columns it expected to add back already existed. This PR adds conditional logic to ensure operations only occur if the target column state is not already met, preventing `Can't DROP` errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-9352106a-fa8d-420d-a9ab-7eb10bc79d4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9352106a-fa8d-420d-a9ab-7eb10bc79d4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>